### PR TITLE
set provider reject timeout without noAckStream check

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ details.
 
 #### Methods
 
-`constructor({ schema, transport, getSubjects, options: { batchSize, highWaterMark, noAckStreams, timeout }}`
+`constructor({ schema, transport, getSubjects, options: { batchSize, highWaterMark, noAckStream, timeout }}`
 
 * `schema`
 
@@ -114,7 +114,7 @@ details.
 
     When set, the stream will push messages in chunks of that size.
 
-  * `noAckStreams`
+  * `noAckStream`
 
     When `true`, allows piping to provider without acknowledgement, i.e. fire
     and forget.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pubsub-store",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Pub/Sub Store",
   "main": "src/index.js",
   "scripts": {

--- a/src/provider.js
+++ b/src/provider.js
@@ -174,7 +174,7 @@ class Provider extends Duplex {
     );
 
     this._create = exec(
-      partial(request, [this._subjects.create[0]]), { noAckStream, timeout }
+      partial(request, [this._subjects.create[0]]), { timeout }
     );
 
     // Allows piping to provider without acknowledgement, i.e. fire and forget

--- a/src/provider.js
+++ b/src/provider.js
@@ -176,7 +176,7 @@ class Provider extends Duplex {
     );
 
     this._create = exec(
-      partial(request, [this._subjects.create[0]]), { timeout }
+      partial(request, [this._subjects.create[0]]), { noAckStream, timeout }
     );
 
     // Allows piping to provider without acknowledgement, i.e. fire and forget

--- a/src/provider.js
+++ b/src/provider.js
@@ -76,14 +76,12 @@ const exec = curry((request, { noAckStream, timeout }, query) => new Promise(
         // reject query on timeout
         // NB: timeout is set in Promise context only when noAckStream
         //     is false and is cancelled in request callback
-        tap(partial(clearTimeout, [ !noAckStream
-          ? setTimeout(
-            partial(reject, [
-              new ProviderError(`query timeout after ${timeout}ms`, query)
-            ]),
-            timeout
-          )
-          : null
+        tap(partial(clearTimeout, [ setTimeout(
+          partial(reject, [
+            new ProviderError(`query timeout after ${timeout}ms`, query)
+          ]),
+          timeout
+        )
         ])),
         JSON.parse,
 


### PR DESCRIPTION
Currently the `noAckStream` option is implemented only when the provider is used as a stream. When the `create` method is called directly, it does not use the `noAckStream` option. All other methods should return an entity, so noAckStream cannot be implemented. Apparently we made this fix in September 2019, but never merged it.

In this MR:
- Pass the `noAckStream` option on `create`
- Minor fix in the Readme file